### PR TITLE
change schedule to be in early morning

### DIFF
--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -296,11 +296,11 @@ harvest_job = define_asset_job(
     selection=AssetSelection.all(),
 )
 
-DAILY_AT_FOUR_PM_UTC_11AM_EST_8AM_PST = "0 16 * * *"
+DAILY_AT_FOUR_AM_EST_1AM_PST = "0 9 * * *"
 
 
 @schedule(
-    cron_schedule=DAILY_AT_FOUR_PM_UTC_11AM_EST_8AM_PST,
+    cron_schedule=DAILY_AT_FOUR_AM_EST_1AM_PST,
     target=AssetSelection.all(),
     default_status=DefaultScheduleStatus.STOPPED,
 )


### PR DESCRIPTION
Do the crawl at four am in the morning in EST or 1AM PST so it presumably is done during a time in which less users are accessing the API