### PR TITLE
new iotid generation strategy

### DIFF
--- a/userCode/odwr/sta_generation.py
+++ b/userCode/odwr/sta_generation.py
@@ -1,7 +1,5 @@
 from typing import Optional
 
-from userCode.common.lib import deterministic_hash
-
 
 from .types import Attributes, Datastream, Observation, StationData
 from userCode.common.ontology import ONTOLOGY_MAPPING
@@ -18,26 +16,25 @@ def to_sensorthings_observation(
     if datapoint is None:
         raise RuntimeError("Missing datapoint")
 
-    # generate a unique hash for the observation since we don't have any other way of
-    # uniquely identifying it from the upstream apii
-    # We have to use a hash since FROST limits the number of characters. We can't just
-    # concat the identifiers together sinec they might be too long
+    # generate a unique id by concatenating the datastream id and the resultTime
+    # we assume that the resultTime is in the format YYYY-MM-DDTHH:MM:SSZ and
+    # that when it is concat with the datastream id it will be unique and less than 18 characters in total
+    strippedResultTime = resultTime.removesuffix("Z")
+    assert strippedResultTime.endswith(
+        "00:00:00"
+    ), "resultTime does not end with 00:00:00 so we would lose information if we removed it"
+    strippedResultTime = strippedResultTime.removesuffix("00:00:00")
+    uniqueId = f"{associatedDatastream.iotid}{strippedResultTime}"
+    uniqueIdJustNumerical = "".join(filter(str.isdigit, uniqueId))
     MAX_LENGTH_IOTID_FOR_FROST = 18
-    id = f"{associatedDatastream.name}{datapoint}{resultTime}"
-    hashedId = deterministic_hash(id, MAX_LENGTH_IOTID_FOR_FROST)
-
-    ###### Other option that could theoretically work but can't have a guarantee of uniqueness if datapoint is a long float
-    ###### or a date with the seconds / minutes specified
-    # strippedResultTime = resultTime.removesuffix("Z")
-    # assert strippedResultTime.endswith("00:00:00"), "resultTime is not a UTC timestamp"
-    # strippedResultTime = strippedResultTime.removesuffix("00:00:00")
-    # uniqueId = f"{associatedDatastream.iotid}{datapoint}{strippedResultTime}"
-    # uniqueIdJustNumerical = "".join(filter(str.isdigit, uniqueId))
+    assert (
+        len(uniqueIdJustNumerical) <= MAX_LENGTH_IOTID_FOR_FROST
+    ), f"@iot.id {uniqueIdJustNumerical} is too long to insert into FROST when constructed with {associatedDatastream.iotid} and {strippedResultTime}"
 
     return Observation(
         **{
             "phenomenonTime": phenom_time,
-            "@iot.id": hashedId,
+            "@iot.id": uniqueIdJustNumerical,
             "resultTime": resultTime,
             "Datastream": {"@iot.id": associatedDatastream.iotid},
             "result": datapoint,


### PR DESCRIPTION
Generating a unique id from oregon observations is non-trivial. Datastreams are not given ids in the upstream api so we generate their id by concatting the station number the number of the datastream. (i.e. if station number is 100 and it is the first datastream, the iot.id for the datastream would be '100' + '0' = '1000'

Given the fact that datastreams are unique we can generate a unique id for an observation by concatting the datastream with the date of the observation. 
Note, this relies upon the fact that

The concat result will not be greater than 18 digits which appears to be the max digits for a long and thus the max digits allowed for iotid in FROST. This in turn relies upon the fact that:
1. All our times just have empty 00:00 values at the end that can be removed. If this isnt the case then we either lose info by stripping it (i.e. there could be multiple data points in a given minute) or we have something that is too long for the iot.id
2. We don't have double digit numbers of datastreams, since otherwise if we had 100+ datastreams it could cause the iot.id to be too long.
3. There arent multiple results for the same datastream at the same time. If this was the case then we would need to also use the result in the iot.id generation. 

I considered hashing but the issue with hashing is that it is possible for two observations to hash to the same value. If this is the case then the entire batch fails and there isnt a clean way to override this. Hashing sort of obscures the fact that ids are just being assumed from the datastream and the date either way.