### PR TITLE
fix ordering of data in the parse set

### DIFF
--- a/userCode/common/test_lib.py
+++ b/userCode/common/test_lib.py
@@ -3,9 +3,9 @@ from hypothesis import given, strategies as st
 
 
 def test_deterministic_hash():
-    assert deterministic_hash("test", 5) == 28374, (
-        "Hashes should be deterministic across runs"
-    )
+    assert (
+        deterministic_hash("test", 5) == 28374
+    ), "Hashes should be deterministic across runs"
 
 
 def test_iow_hash_is_deterministic():

--- a/userCode/common/test_lib.py
+++ b/userCode/common/test_lib.py
@@ -3,9 +3,9 @@ from hypothesis import given, strategies as st
 
 
 def test_deterministic_hash():
-    assert (
-        deterministic_hash("test", 5) == 28374
-    ), "Hashes should be deterministic across runs"
+    assert deterministic_hash("test", 5) == 28374, (
+        "Hashes should be deterministic across runs"
+    )
 
 
 def test_iow_hash_is_deterministic():
@@ -37,3 +37,14 @@ def test_hash_is_positive_fuzz(name, desiredLength):
     assert result > 0, f"Hash result should always be positive, got {result}"
     # can be less since the result may be padded at the start with 0s
     assert len(str(result)) <= desiredLength
+
+
+@given(st.lists(st.text(), unique=True))
+def test_dict_is_the_same_as_ordered_set(listOfArbitraryStrings: list[str]):
+    # Use fromkeys to create a dictionary
+    dict_from_keys = dict.fromkeys(listOfArbitraryStrings)
+    for _, v in dict_from_keys.items():
+        assert v is None
+
+    # Assert the order of keys is the same as the input order
+    assert list(dict_from_keys.keys()) == listOfArbitraryStrings

--- a/userCode/odwr/lib.py
+++ b/userCode/odwr/lib.py
@@ -81,9 +81,9 @@ def parse_oregon_tsv(
                 data.append(float(row[2]))
 
             parsed_date = parse_date(str(DATE_COLUMN))
-            assert parsed_date not in unique_dates, (
-                f"Date '{parsed_date}' appeared twice in the data"
-            )
+            assert (
+                parsed_date not in unique_dates
+            ), f"Date '{parsed_date}' appeared twice in the data"
             unique_dates[parsed_date] = None
 
     return ParsedTSVData(data, units, list(unique_dates))

--- a/userCode/odwr/lib.py
+++ b/userCode/odwr/lib.py
@@ -49,7 +49,10 @@ def parse_oregon_tsv(
     # url does not match the name in the result column. However,
     # it consistently is returned in the third column
     data: list[Optional[float]] = []
-    dates: set[str] = set()
+
+    # in python set is not ordered but a dict is
+    # so we can essentially use it as a set and ignore the values
+    unique_dates: dict[str, None] = {}
     units = "Unknown"
     tsv_data = io.StringIO(response.decode("utf-8"))
     reader = csv.reader(tsv_data, delimiter="\t")
@@ -78,12 +81,12 @@ def parse_oregon_tsv(
                 data.append(float(row[2]))
 
             parsed_date = parse_date(str(DATE_COLUMN))
-            assert (
-                parsed_date not in dates
-            ), f"Date '{parsed_date}' appeared twice in the data"
-            dates.add(parsed_date)
+            assert parsed_date not in unique_dates, (
+                f"Date '{parsed_date}' appeared twice in the data"
+            )
+            unique_dates[parsed_date] = None
 
-    return ParsedTSVData(data, units, list(dates))
+    return ParsedTSVData(data, units, list(unique_dates))
 
 
 def unix_offset_to_iso(unix_offset: int) -> str:

--- a/userCode/odwr/tests/lib.py
+++ b/userCode/odwr/tests/lib.py
@@ -101,14 +101,14 @@ def assert_observations_and_datastreams_empty():
     """Make sure that the observations and datastreams contain no data"""
     datastreams = requests.get(f"{API_BACKEND_URL}/Datastreams")
     assert datastreams.ok, "Failed to get datastreams"
-    assert datastreams.json() == {"value": []}, (
-        "Datastreams are not empty at the start of the pipeline test"
-    )
+    assert datastreams.json() == {
+        "value": []
+    }, "Datastreams are not empty at the start of the pipeline test"
     obs = requests.get(f"{API_BACKEND_URL}/Observations")
     assert obs.ok, "Failed to get observations"
-    assert obs.json() == {"value": []}, (
-        "Observations are not empty at the start of the pipeline test"
-    )
+    assert obs.json() == {
+        "value": []
+    }, "Observations are not empty at the start of the pipeline test"
 
 
 def assert_no_duplicate_at_given_time(
@@ -119,9 +119,9 @@ def assert_no_duplicate_at_given_time(
     url = f"{API_BACKEND_URL}/Datastreams({datastream_int})/Observations?$filter=resultTime%20eq%20{date_to_check.strftime('%Y-%m-%dT%H:%M:%SZ')}"
     resp = requests.get(url)
     assert resp.ok, resp.text
-    assert len(resp.json()["value"]) <= 1, (
-        f"There appear to be multiple observations at the same resultTime for the datastream {datastream_int}"
-    )
+    assert (
+        len(resp.json()["value"]) <= 1
+    ), f"There appear to be multiple observations at the same resultTime for the datastream {datastream_int}"
 
 
 def assert_no_observations_with_same_iotid_in_first_page():

--- a/userCode/odwr/tests/lib.py
+++ b/userCode/odwr/tests/lib.py
@@ -101,14 +101,14 @@ def assert_observations_and_datastreams_empty():
     """Make sure that the observations and datastreams contain no data"""
     datastreams = requests.get(f"{API_BACKEND_URL}/Datastreams")
     assert datastreams.ok, "Failed to get datastreams"
-    assert datastreams.json() == {
-        "value": []
-    }, "Datastreams are not empty at the start of the pipeline test"
+    assert datastreams.json() == {"value": []}, (
+        "Datastreams are not empty at the start of the pipeline test"
+    )
     obs = requests.get(f"{API_BACKEND_URL}/Observations")
     assert obs.ok, "Failed to get observations"
-    assert obs.json() == {
-        "value": []
-    }, "Observations are not empty at the start of the pipeline test"
+    assert obs.json() == {"value": []}, (
+        "Observations are not empty at the start of the pipeline test"
+    )
 
 
 def assert_no_duplicate_at_given_time(
@@ -116,12 +116,12 @@ def assert_no_duplicate_at_given_time(
 ):
     """Checks if there are multiple observations at the same time for a given datastream"""
     # This is in a format like https://owdp-pilot.internetofwater.app/FROST-Server/v1.1/Datastreams(140805000)/Observations?$filter=resultTime%20eq%201941-10-01T00:00:00Z
-    url = f"{API_BACKEND_URL}/Datastreams({datastream_int})/Observations?$filter=resultTime%20eq%20{date_to_check.strftime("%Y-%m-%dT%H:%M:%SZ")}"
+    url = f"{API_BACKEND_URL}/Datastreams({datastream_int})/Observations?$filter=resultTime%20eq%20{date_to_check.strftime('%Y-%m-%dT%H:%M:%SZ')}"
     resp = requests.get(url)
     assert resp.ok, resp.text
-    assert (
-        len(resp.json()["value"]) <= 1
-    ), f"There appear to be multiple observations at the same resultTime for the datastream {datastream_int}"
+    assert len(resp.json()["value"]) <= 1, (
+        f"There appear to be multiple observations at the same resultTime for the datastream {datastream_int}"
+    )
 
 
 def assert_no_observations_with_same_iotid_in_first_page():

--- a/userCode/odwr/tests/test_upstream.py
+++ b/userCode/odwr/tests/test_upstream.py
@@ -234,3 +234,20 @@ def test_adding_one_minute_prevents_overlap(begin, end_time):
 
     for date in parsedResp1.dates:
         assert date not in parsedResp2.dates
+
+
+# run this multiple times to make sure it is consistent
+@pytest.mark.parametrize("execution_number", range(5))
+def test_our_download_matches_ui(execution_number):
+    res = download_oregon_tsv(
+        "mean_daily_flow_available",
+        10378500,
+        start_date="1/1/2025",
+        end_date="1/9/2025",
+    )
+    # 'https://apps.wrd.state.or.us/apps/sw/hydro_near_real_time/hydro_download.aspx?station_nbr=10378500&start_date=1/1/2025&end_date=1/9/2025&dataset=MDF&format=tsv&units='
+    parsed = parse_oregon_tsv(res)
+    assert parsed.data[0] == 16.9
+    assert parsed.data[1] == 15.0
+    for i in range(8):
+        assert f"2025-01-0{i + 1}" in parsed.dates[i]


### PR DESCRIPTION
sets dont preserve order when casting to a list but a dictionary does. As such I switch to a dict and add some tests to make sure this order is preserved