### PR TITLE
make the empty data check less strict

### DIFF
--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -164,7 +164,7 @@ def sta_all_observations(
 
     async def fetch_obs(datastream: Datastream) -> List[Observation]:
         """Fetch observations for a single datastream and return them."""
-        local_observations = [] # the observations array local to this function. 
+        local_observations = []  # the observations array local to this function.
         range = get_datastream_time_range(datastream.iotid)
 
         new_end = (
@@ -202,9 +202,9 @@ def sta_all_observations(
             RUNNING_AS_A_TEST_NOT_IN_PROD = "PYTEST_CURRENT_TEST" in os.environ
             if RUNNING_AS_A_TEST_NOT_IN_PROD:
                 key = (datastream.iotid, date)
-                assert key not in seen_obs, (
-                    f"Found duplicate observation {key} after {i} iterations for station {attr.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url} for date range {range.start} to {new_end}"
-                )
+                assert (
+                    key not in seen_obs
+                ), f"Found duplicate observation {key} after {i} iterations for station {attr.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url} for date range {range.start} to {new_end}"
                 seen_obs.add(key)
 
             sta_representation = to_sensorthings_observation(

--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -164,7 +164,7 @@ def sta_all_observations(
 
     async def fetch_obs(datastream: Datastream) -> List[Observation]:
         """Fetch observations for a single datastream and return them."""
-        local_observations = []
+        local_observations = [] # the observations array local to this function. 
         range = get_datastream_time_range(datastream.iotid)
 
         new_end = (
@@ -202,9 +202,9 @@ def sta_all_observations(
             RUNNING_AS_A_TEST_NOT_IN_PROD = "PYTEST_CURRENT_TEST" in os.environ
             if RUNNING_AS_A_TEST_NOT_IN_PROD:
                 key = (datastream.iotid, date)
-                assert (
-                    key not in seen_obs
-                ), f"Found duplicate observation {key} after {i} iterations for station {attr.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url} for date range {range.start} to {new_end}"
+                assert key not in seen_obs, (
+                    f"Found duplicate observation {key} after {i} iterations for station {attr.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url} for date range {range.start} to {new_end}"
+                )
                 seen_obs.add(key)
 
             sta_representation = to_sensorthings_observation(
@@ -212,9 +212,13 @@ def sta_all_observations(
             )
             local_observations.append(sta_representation)
 
-        assert (
-            len(local_observations) > 0
-        ), f"No observations found in range {range.start} to {new_end} for station {station_metadata.attributes.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url}"
+        if len(local_observations) == 0:
+            # We don't raise an exception since this isn't a fatal error, but it is suspicious so we
+            # log it as a runtime error so it has high visibility. There are cases in the upstream API where
+            # there will be lots of missing data for an unknown reason
+            get_dagster_logger().error(
+                f"No observations found in range {range.end} to {new_end} for station {station_metadata.attributes.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url}"
+            )
 
         return local_observations
 


### PR DESCRIPTION
turn this into a logged error instead of a runtime exception. it appears there are sometimes ranges in which there is no data so it is good to make note of but it doesnt signify an error

```
The above exception was caused by the following exception:
AssertionError: No observations found in range 2015-06-01 00:00:00+00:00 to 01/13/2025 01:44:22 PM for station 14357000 and datastream 'water_temp_mean' after fetching url: https://apps.wrd.state.or.us/apps/sw/hydro_near_real_time/hydro_download.aspx?station_nbr=14357000&start_date=11%2F23%2F2024+12%3A01%3A00+AM&end_date=01%2F13%2F2025+01%3A44%3A22+PM&dataset=WTEMP_MEAN&format=tsv&units=
```