### PR TITLE
ignore caching all together in prod

### DIFF
--- a/userCode/odwr/lib.py
+++ b/userCode/odwr/lib.py
@@ -92,9 +92,9 @@ def parse_oregon_tsv(
                 data.append(float(row[2]))
 
             parsed_date = parse_date(str(DATE_COLUMN))
-            assert parsed_date not in unique_dates, (
-                f"Date '{parsed_date}' appeared twice in the data"
-            )
+            assert (
+                parsed_date not in unique_dates
+            ), f"Date '{parsed_date}' appeared twice in the data"
             unique_dates[parsed_date] = None
 
     return ParsedTSVData(data, units, list(unique_dates))

--- a/userCode/odwr/lib.py
+++ b/userCode/odwr/lib.py
@@ -9,6 +9,7 @@
 # =================================================================
 
 import csv
+import os
 from dagster import get_dagster_logger
 import datetime
 import io
@@ -91,9 +92,9 @@ def parse_oregon_tsv(
                 data.append(float(row[2]))
 
             parsed_date = parse_date(str(DATE_COLUMN))
-            assert (
-                parsed_date not in unique_dates
-            ), f"Date '{parsed_date}' appeared twice in the data"
+            assert parsed_date not in unique_dates, (
+                f"Date '{parsed_date}' appeared twice in the data"
+            )
             unique_dates[parsed_date] = None
 
     return ParsedTSVData(data, units, list(unique_dates))
@@ -158,8 +159,17 @@ def download_oregon_tsv(
     """Get the tsv data for a specific dataset for a specific station in a given date range"""
     tsv_url = generate_oregon_tsv_url(dataset, station_nbr, start_date, end_date)
 
-    cache = ShelveCache()
-    response, status_code = cache.get_or_fetch(tsv_url, force_fetch=False)
+    RUNNING_AS_A_TEST_NOT_IN_PROD = "PYTEST_CURRENT_TEST" in os.environ
+
+    if RUNNING_AS_A_TEST_NOT_IN_PROD:
+        # If we are in a test, we want to use the cache to avoid making too many requests while testing
+        # But in production, we always want to fetch and not cache anything to avoid extra data
+        cache = ShelveCache()
+        response, status_code = cache.get_or_fetch(tsv_url, force_fetch=False)
+    else:
+        fetch_result = requests.get(tsv_url)
+        status_code = fetch_result.status_code
+        response = fetch_result.content
 
     if status_code != 200 or "An Error Has Occured" in response.decode("utf-8"):
         raise RuntimeError(


### PR DESCRIPTION
shelve should cache locally so we have faster tests and dont always fetch the same data
in prod we can ignore this all together and save some disk space

dont think this is the issue on the VM just since I dont see the file anywhere. but perhaps something is going on weird so i will remove this to be safe.