### PR TITLE
cleaner shelve cache handling

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,7 +1,6 @@
-# start the reverse proxy which gives our server https and points to the proper domain
-caddy:
-	cp ./Caddyfile /etc/caddy/Caddyfile
-	sudo systemctl restart caddy
+###### Docker Compose Commands
+## We use these since there is a production profile and without specifying the profile
+## docker will not start those services. This can be a footgun
 
 prodUp:
 	docker compose --profile production up -d
@@ -12,7 +11,15 @@ prodBuild:
 prodDown:
 	docker compose --profile production down
 
+####### Helper Commands
+
+# start the reverse proxy which gives our server https and points to the proper domain
+caddy:
+	cp ./Caddyfile /etc/caddy/Caddyfile
+	sudo systemctl restart caddy
+
 # get rid of the sensorthings db, mainly for testing purposes
+# or if you need to recrawl. NOTE that you may need to reapply the indices after
 wipedb:
 	docker volume rm oregonwaterdataportal-etl_postgis_volume
 

--- a/userCode/cache.py
+++ b/userCode/cache.py
@@ -16,6 +16,7 @@ import requests
 import shelve
 from typing import ClassVar, Optional, Tuple
 
+from userCode.env import RUNNING_IN_TEST_ENVIRONMENT
 from userCode.util import deterministic_hash
 
 
@@ -38,6 +39,11 @@ class ShelveCache:
             get_dagster_logger().warning(f"Unable to cache: {url}")
 
     def get_or_fetch(self, url: str, force_fetch: bool = False) -> Tuple[bytes, int]:
+        # If we are in prod we want to ignore using the cache and not store anything
+        if not RUNNING_IN_TEST_ENVIRONMENT:
+            response = requests.get(url, headers=HEADERS, timeout=300)
+            return response.content, response.status_code
+
         if self.contains(url) and not force_fetch:
             try:
                 return self.get(url), 200

--- a/userCode/env.py
+++ b/userCode/env.py
@@ -15,4 +15,7 @@ import os
 API_BACKEND_URL = get_env("API_BACKEND_URL")
 AWQMS_URL = "https://ordeq.gselements.com/api"
 
-RUNNING_AS_A_TEST_NOT_IN_PROD = "PYTEST_CURRENT_TEST" in os.environ
+# If we are running inside of pytest, pytest will set this environment variable
+# We can use this to cache data, check more strictly, or do other optimizations
+# we wouldn't necessarily want to do in production
+RUNNING_IN_TEST_ENVIRONMENT = "PYTEST_CURRENT_TEST" in os.environ

--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -27,7 +27,7 @@ import httpx
 import requests
 from typing import List, Optional, Tuple
 
-from userCode.env import API_BACKEND_URL, RUNNING_AS_A_TEST_NOT_IN_PROD
+from userCode.env import API_BACKEND_URL, RUNNING_IN_TEST_ENVIRONMENT
 from userCode.helper_classes import BatchHelper, get_datastream_time_range, MockValues
 from userCode.odwr.lib import (
     fetch_station_metadata,
@@ -194,11 +194,11 @@ def sta_all_observations(
             # If we are running this as a test, we want to keep track of which observations we have seen so we can detect duplicates
             # We don't want to cache every single observation unless we are running as a test since the db will catch duplicates as well
             # This is a further check to be thorough
-            if RUNNING_AS_A_TEST_NOT_IN_PROD:
+            if RUNNING_IN_TEST_ENVIRONMENT:
                 key = (datastream.iotid, date)
-                assert (
-                    key not in seen_obs
-                ), f"Found duplicate observation {key} after {i} iterations for station {attr.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url} for date range {range.start} to {new_end}"
+                assert key not in seen_obs, (
+                    f"Found duplicate observation {key} after {i} iterations for station {attr.station_nbr} and datastream '{datastream.description}' after fetching url: {tsv_url} for date range {range.start} to {new_end}"
+                )
                 seen_obs.add(key)
 
             sta_representation = to_sensorthings_observation(


### PR DESCRIPTION
- makes shelve cache only work in a pytest env and be ignored in prod, moves this logic into shelve cache itself
-  also clean up some comments in the makefile 