### PR TITLE
Add Prometheus and Grafana for Node and Postgres Observability

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -26,12 +26,34 @@ services:
     volumes:
       - postgis_volume:/var/lib/postgresql/data
 
+  postgres-exporter:
+    container_name: postgres-exporter
+    image: prometheuscommunity/postgres-exporter:latest
+    restart: unless-stopped
+    environment: 
+      - DATA_SOURCE_NAME=postgresql://sensorthings:ChangeMe@owdp-database:5432/sensorthings?sslmode=disable
+    ports:
+      - 9187:9187
+
+  node-exporter:
+    image: prom/node-exporter
+    volumes:
+      - /proc:/host/proc:ro
+      - /sys:/host/sys:ro
+      - /:/rootfs:ro
+    command:
+      - "--path.procfs=/host/proc"
+      - "--path.sysfs=/host/sys"
+      - "--collector.filesystem.ignored-mount-points=^/(sys|proc|dev|host|etc)($|/)"
+
+
   owdp-pygeoapi:
     container_name: owdp-pygeoapi
     build:
       context: docker/pygeoapi
     depends_on:
       - owdp-frost
+    restart: unless-stopped
     environment:
       - API_URL=${OWDP_URL}/oapi
       - API_BACKEND_URL=http://owdp-frost:8080/FROST-Server/v1.1
@@ -98,5 +120,29 @@ services:
     profiles: [production]
     restart: always
 
+  owdp-prometheus:
+    image: prom/prometheus
+    container_name: owdp-prometheus
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - 9090:9090
+    restart: unless-stopped
+    volumes:
+      - ./docker/prometheus:/etc/prometheus
+      - prom_data:/prometheus
+  owdp-grafana:
+    image: grafana/grafana
+    container_name: owdp-grafana
+    ports:
+      - 4000:3000
+    restart: unless-stopped
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    volumes:
+      - ./docker/grafana:/etc/grafana/provisioning/datasources
+
 volumes:
   postgis_volume:
+  prom_data:

--- a/docker/grafana/datasource.yml
+++ b/docker/grafana/datasource.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+datasources:
+- name: Prometheus
+  type: prometheus
+  url: http://owdp-prometheus:9090 
+  isDefault: true
+  access: proxy
+  editable: true
+- name: Postgresql
+  type: postgres
+  url: http://owdp-postgresql:5432
+  user: sensorthings
+  secureJsonData:
+      password: 'ChangeMe'

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,34 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets: []
+    scheme: http
+    timeout: 10s
+    api_version: v2
+scrape_configs:
+- job_name: prometheus
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  static_configs:
+  - targets:
+    - localhost:9090
+- job_name: postgres
+  static_configs:
+    - targets: ["postgres-exporter:9187"]
+- job_name: 'node'
+  static_configs:
+    - targets: ['node-exporter:9100']
+
+remote_write:
+  - url: owdp-grafana:3000
+    basic_auth:
+      username: admin
+      password: grafana
+


### PR DESCRIPTION
Wanted to play around with adding prometheus and grafana to the the deployment stack. Adds a metrics exporter for postgres as well as the VM itself so we can get better observability into the FROST server. I would like to eventually get rid of that container monitoring bot and use prometheus alerts since they are more robust and generalized.

Might be helpful for future service work to have a working config somewhere even if we don't merge this for Oregon.

It is an open question if this is better than a managed solution from Google. I like being able to run this all locally and use more cloud native standard tooling instead of Google cloud APIs fwiw