### PR TITLE
Run crawl odwr more often

### DIFF
--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -340,6 +340,7 @@ odwr_job = define_asset_job(
 
 EVERY_4_HOURS = "0 */4 * * *"
 
+
 @schedule(
     cron_schedule=EVERY_4_HOURS,
     target=AssetSelection.groups("owdp"),

--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -338,10 +338,10 @@ odwr_job = define_asset_job(
     selection=AssetSelection.groups("owdp"),
 )
 
-EVERY_6_HOURS = "0 */6 * * *"
+EVERY_4_HOURS = "0 */4 * * *"
 
 @schedule(
-    cron_schedule=EVERY_6_HOURS,
+    cron_schedule=EVERY_4_HOURS,
     target=AssetSelection.groups("owdp"),
     default_status=DefaultScheduleStatus.STOPPED
     if RUNNING_AS_TEST_OR_DEV()

--- a/userCode/odwr/dag.py
+++ b/userCode/odwr/dag.py
@@ -338,11 +338,10 @@ odwr_job = define_asset_job(
     selection=AssetSelection.groups("owdp"),
 )
 
-DAILY_AT_4AM_EST_1AM_PST = "0 9 * * *"
-
+EVERY_6_HOURS = "0 */6 * * *"
 
 @schedule(
-    cron_schedule=DAILY_AT_4AM_EST_1AM_PST,
+    cron_schedule=EVERY_6_HOURS,
     target=AssetSelection.groups("owdp"),
     default_status=DefaultScheduleStatus.STOPPED
     if RUNNING_AS_TEST_OR_DEV()


### PR DESCRIPTION
This doesn't necessarily solve the time issue if it is offset wrong but it does make it so the data should be in the system faster

Crawling is very fast and cheap since we are just updating 1 days work of data so it should be fine to do this every 4 hours